### PR TITLE
ci: switch to pull_request_target event

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,12 @@ name: Test
 
 on:
   workflow_dispatch:
-  pull_request:
+  # Use a manual approval process before PR's are given access to
+  # the secrets which are required to run the integration tests.
+  # The PR code should be manually approved to see if it can be trusted.
+  # When in doubt, do not approve the test run.
+  # Reference: https://dev.to/petrsvihlik/using-environment-protection-rules-to-secure-secrets-when-building-external-forks-with-pullrequesttarget-hci
+  pull_request_target:
     branches:
       - main
   merge_group:


### PR DESCRIPTION
Trigger tests on pull_request_target to an approval mechanism before accessing secrets.