### PR TITLE
feat: attach thing to certificate principal

### DIFF
--- a/tests/composite.robot
+++ b/tests/composite.robot
@@ -1,0 +1,15 @@
+*** Settings ***
+
+Resource            ./resources/common.resource
+Library             AWS
+
+*** Test Cases ***
+
+Create Certificate and Thing
+    ${response}=     AWS.Create Thing With Self-Signed Certificate
+    Should Not Be Empty    ${response.name}
+    Should Not Be Empty    ${response.policy_name}
+    Should Not Be Empty    ${response.private_key}
+    Should Not Be Empty    ${response.public_key}
+
+    AWS.Thing Should Exist    ${response.name}

--- a/tests/thing.robot
+++ b/tests/thing.robot
@@ -13,6 +13,19 @@ Create Thing with auto cleanup
     ${response}=    AWS.Thing Should Exist    ${name}
     Should Not Be Empty    ${response}
 
+Create Thing with Principal
+    ${thing_name}=    AWS.Get Random Name
+
+    ${policy_name}=    AWS.Get Random Name
+    AWS.Create Policy    ${policy_name}
+
+    ${cert_key_path}=    AWS.Create Certificate Private Key
+    ${cert_pub}=    AWS.Create Self-Signed Certificate    ${cert_key_path}    ${thing_name}
+    ${cert_response}=    Register Self-Signed Certificate    ${cert_pub}    policy_name=${policy_name}
+
+    AWS.Create Thing    ${thing_name}    certificate_arn=${cert_response["certificateArn"]}
+    AWS.Thing Should Exist    ${thing_name}
+
 Delete Thing
     ${name}    AWS.Get Random Name
     ${thing}=    AWS.Create Thing    ${name}    auto_delete=${False}


### PR DESCRIPTION
* Add option to attach a certificate (principal) to a thing when creating it
* Add composite command to create a new thing with a self-signed certificate