### PR TITLE
feat: align access key env variable name with aws standard

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,7 +81,7 @@ jobs:
         run: |
           touch .env
           echo 'AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"' >> .env
-          echo 'AWS_ACCESS_KEY="${{ secrets.AWS_ACCESS_KEY }}"' >> .env
+          echo 'AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"' >> .env
           echo 'AWS_REGION="${{ secrets.AWS_REGION }}"' >> .env
 
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Robot Framework Library for AWS IoT in the context of thin-edge.io
 
     ```sh
     AWS_ACCESS_KEY_ID=ABCDEFGHI
-    AWS_ACCESS_KEY=<secret>
+    AWS_SECRET_ACCESS_KEY=<secret>
     AWS_REGION=us-east-1
     ```
 

--- a/tests/resources/common.resource
+++ b/tests/resources/common.resource
@@ -1,3 +1,3 @@
 *** Variables ***
 
-&{AWS_CONFIG}        access_key_id=%{AWS_ACCESS_KEY_ID= }    access_key=%{AWS_ACCESS_KEY= }    region=%{AWS_REGION= }
+&{AWS_CONFIG}        access_key_id=%{AWS_ACCESS_KEY_ID= }    access_key=%{AWS_SECRET_ACCESS_KEY= }    region=%{AWS_REGION= }


### PR DESCRIPTION
Rename `AWS_ACCESS_KEY` to `AWS_SECRET_ACCESS_KEY` to be more compatible with other AWS libraries