### PR TITLE
ci: fail if skipped matrix runs are detected

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -105,6 +105,13 @@ jobs:
   passed:
     runs-on: ubuntu-latest
     needs: test
+    if: always()
     steps:
-      - run: |
-          echo Tests passed
+      - name: Fail on workflow error
+        run: exit 1
+        if: >-
+          ${{
+            contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+            || contains(needs.*.result, 'skipped')
+          }}


### PR DESCRIPTION
Avoid merging a PR in the merge queue due to the "passed" job being marked as healthy even though it was skipped due to upstream failures