### PR TITLE
feat: add the iot:RetainPublish permissions to the default policy

### DIFF
--- a/AWS/policy.py
+++ b/AWS/policy.py
@@ -40,7 +40,7 @@ class Policy:
     },
     {
       "Effect": "Allow",
-      "Action": "iot:Publish",
+      "Action": ["iot:Publish", "iot:RetainPublish"],
       "Resource": [
         "arn:aws:iot:{{REGION}}:{{ACCOUNT_ID}}:topic/thinedge/${iot:Connection.Thing.ThingName}/td",
         "arn:aws:iot:{{REGION}}:{{ACCOUNT_ID}}:topic/thinedge/${iot:Connection.Thing.ThingName}/td/*",


### PR DESCRIPTION
Allow clients to also publish retained messages to AWS