### PR TITLE
fix: add ref parameter to checkout action for pull_request_target event

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"

--- a/AWS/random.py
+++ b/AWS/random.py
@@ -1,5 +1,7 @@
 """Random data generator"""
 
+import re
+
 import randomname
 
 
@@ -40,4 +42,4 @@ class RandomNameGenerator:
             # then one noun
             groups.append("n/")
 
-        return randomname.generate(*groups, sep=sep)
+        return re.sub(r"[^\w+=,.@-]", sep, randomname.generate(*groups, sep=sep))


### PR DESCRIPTION
Without specifying the given reference, it meant that the PR checks were always being run against the main branch.